### PR TITLE
fix.ie.variables - bad variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -402,7 +402,7 @@ var EnbBevisHelperBase = inherit(ModuleConfig, /** @lends EnbBevisHelperBase.pro
                 ]);
             });
 
-            configureCssBuild(null, browserSupport, {ie: false});
+            configureCssBuild(null, browserSupport, {});
 
             if (this._ie8Suffix) {
                 configureCssBuild(this._ie8Suffix, ['ie 8'], {ie: 8});


### PR DESCRIPTION
```
ie = false;
.box {
  if (ie <= 9) {
    color: red;
  } else {
    color: black; 
  }
}
```

?.css: 

```
.box {
  color: red;
}
```
